### PR TITLE
fix: adjust period sorting for new SMS API response order

### DIFF
--- a/apps/api/src/routes/dashboard/terms/_yearID/index.js
+++ b/apps/api/src/routes/dashboard/terms/_yearID/index.js
@@ -44,8 +44,14 @@ export default async function (fastify) {
         cookie,
       })
 
-      periods.data[getCurrentQuarter() - 1].isActual = true
-      await reply.send(periods.data)
+      const sortedPeriods = periods.data.sort((a, b) => {
+        if (a.Name < b.Name) return -1;
+        if (a.Name > b.Name) return 1;
+        return 0;
+      });
+
+      sortedPeriods[getCurrentQuarter() - 1].isActual = true;
+      await reply.send(sortedPeriods);
     }
   )
 }


### PR DESCRIPTION
The SMS API now returns quarters in descending order, causing incorrect current quarter calculations and quarter selection. 